### PR TITLE
Remove custom OHC namedCollection field from config

### DIFF
--- a/tomcat-main/src/main/resources/tenants/ohc/ohc-collectionobject.xml
+++ b/tomcat-main/src/main/resources/tenants/ohc/ohc-collectionobject.xml
@@ -26,8 +26,6 @@
 			<field id="subCategory" mini="search" autocomplete="concept-nomenclature" section="ohc" />
 		</repeat>
 
-		<field id="namedCollection" autocomplete="work-work" section="ohc" />
-
 		<section id="objectCollectionInformation">
 			<repeat id="oaiSiteGroupList/oaiSiteGroup" section="ohc">
 				<field id="oaiCollectionPlace" autocomplete="place-place,place-place_shared,place-tgn_place" section ="ohc"/>


### PR DESCRIPTION
This cleans up OHC's configuration so that this unused custom field (replaced by the new community field) is no longer included.