### PR TITLE
OHC Updates

### DIFF
--- a/tomcat-main/src/main/resources/tenants/ohc/domain-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/ohc/domain-instance-vocabularies.xml
@@ -43,36 +43,6 @@
 		</options>
 	</instance>
 
-  <instance id="vocab-namedtimeperiods">
-    <web-url>namedtimeperiods</web-url>
-    <title-ref>namedtimeperiods</title-ref>
-    <title>Named Time Periods</title>
-    <options>
-      <option id="18thcentury">18th century</option>
-      <option id="19thcentury">19th century</option>
-      <option id="20thcentury">20th century</option>
-      <option id="21stcentury">21st century</option>
-      <option id="archaic">Archaic</option>
-      <option id="earlyarchaic">Early Archaic</option>
-      <option id="earlyhistoric">Early Historic</option>
-      <option id="earlylatewoodland">early Late Woodland</option>
-      <option id="earlypaleoindian">Early Paleoindian</option>
-      <option id="earlywoodland">Early Woodland</option>
-      <option id="historic">Historic</option>
-      <option id="latearchaic">Late Archaic</option>
-      <option id="latemiddlewoodland">late Middle Woodland</option>
-      <option id="latepaleoindian">late Paleoindian</option>
-      <option id="lateprehistoric">Late Prehistoric</option>
-      <option id="latewoodland">Late Woodland</option>
-      <option id="middlearchaic">Middle Archaic</option>
-      <option id="middlewoodland">Middle Woodland</option>
-      <option id="modern">Modern</option>
-      <option id="paleoindian">Paleoindian</option>
-      <option id="prehistoric">Prehistoric</option>
-      <option id="woodland">Woodland</option>
-    </options>
-  </instance>
-
   <instance id="vocab-majortaxon">
     <web-url>majortaxon</web-url>
     <title-ref>majortaxon</title-ref>

--- a/tomcat-main/src/main/resources/tenants/ohc/ohc-collectionobject.xml
+++ b/tomcat-main/src/main/resources/tenants/ohc/ohc-collectionobject.xml
@@ -16,7 +16,7 @@
 		<repeat id="determinationHistoryGroupList/determinationHistoryGroup">
 			<field id="determinationTaxon" mini="search,list"/>
 		</repeat>
-  </section>
+	</section>
 
 	<section id="descriptionInformation">
 		<repeat id="materialGroupList/materialGroup">
@@ -47,14 +47,5 @@
 		<field id="descriptionLevel" autocomplete="vocab-descriptionlevel" ui-type="enum" section="ohc" />
 
 		<field id="majorTaxon" autocomplete="vocab-majortaxon" ui-type="enum" section="ohc" />
-
-		<repeat id="namedTimePeriods" section="ohc">
-			<field id="namedTimePeriod" autocomplete="vocab-namedtimeperiods" ui-type="enum" section="ohc" />
-		</repeat>
-		
-		<repeat id="oaiSiteGroupList/oaiSiteGroup" section="ohc">
-			<field id="oaiCollectionPlace" autocomplete="place-place,place-place_shared,place-tgn_place" section ="ohc"/>
-			<field id="oaiLocVerbatim" section="ohc"/>
-		</repeat>
 	</section>
 </record>


### PR DESCRIPTION
**What does this do?**
* Removes namedtimeperiods vocab
* Removes namedTimePeriod field from ohc collectionobject
* Removes oaiCollectionPlace field from ohc collectionobject
* Removes oaiLocVerbatim field from ohc collectionobject

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1408
Jira: https://collectionspace.atlassian.net/browse/DRYD-1407

These are deprecated fields for OHC which are no longer in use and being removed.

**How should this be tested? Do these changes have associated tests?**
* Rebuild collectionspace
* Using the pr in cspace-ui-plugin-profile-ohc.js create a collectionobject in the following templates and see the fields no longer exist:
  * default
  * archaeology parent
  * archaeology child 
* Check the term lists for ohc and see namedtimeperiods does not exist 

**Dependencies for merging? Releasing to production?**
I wasn't sure if this should be merged to this branch or `dts-v8.0-branch`. Since 7.2 is the default I targeted that, but can switch to be on 8.0.

Also the `namedtimeperiod` vocab will likely continue to exist in cspace as it will need to be deleted as well. I believe the change here will only stop it from being persisted when starting the server.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter ran locally (against 8.0)