### PR TITLE
Add missing vocabs from defaults/base-instance-vocabularies into ohc override.

### DIFF
--- a/tomcat-main/src/main/resources/tenants/ohc/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/ohc/base-instance-vocabularies.xml
@@ -2047,4 +2047,36 @@
             <option id="supporting_collection">supporting collection</option>
         </options>
     </instance>
+    <instance id="vocab-objectcounttypes">
+        <web-url>objectcounttypes</web-url>
+        <title-ref>objectcounttypes</title-ref>
+        <title>Object Count Types</title>
+        <options>
+            <option id="collection_count">collection count</option>
+            <option id="inventory_count">inventory count</option>
+            <option id="associated_funerary_objects">associated funerary objects</option>
+            <option id="miniumum_num_of_individuals">minimum number of individuals</option>
+        </options>
+    </instance>
+    <instance id="vocab-assocauthorityrelationtype">
+        <web-url>assocauthorityrelationtype</web-url>
+        <title-ref>assocauthorityrelationtype</title-ref>
+        <title>Associated Authority Relation Types</title>
+        <options>
+            <option id="affiliated">affiliated</option>
+            <option id="affiliated_to">affiliated to</option>
+            <option id="collector">collector</option>
+            <option id="collected_by">collected by</option>
+            <option id="family_member">family member</option>
+            <option id="leader">leader</option>
+            <option id="leader_of">leader of</option>
+            <option id="owner">owner</option>
+            <option id="owned_by">owned by</option>
+            <option id="replica">replica</option>
+            <option id="replica_of">replica of</option>
+            <option id="resident">resident</option>
+            <option id="place_of_residence">place of residence</option>
+            <option id="situated_in">situated in</option>
+        </options>
+    </instance>
 </instances>


### PR DESCRIPTION
**What does this do?**

This adds new-for-8.0 vocabularies defined in defaults/base-instances-vocabularies.xml into OHC's override of that file in tenants/ohc.

**Why are we doing this? (with JIRA link)**

The `objectcounttypes` and `assocauthorityrelationtype` vocabularies were missing from the OHC tenant after upgrade to 8.0.

**How should this be tested? Do these changes have associated tests?**

- On an Object record, open the Object Count / Type field dropdown. Values should appear.
- On a Chronology record, open the Associated Person / Relationship/Type field dropdown. Values. should appear.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this locally.